### PR TITLE
 Added new recursion control per type

### DIFF
--- a/MyTriggers/framework/classes/MyTriggers.cls
+++ b/MyTriggers/framework/classes/MyTriggers.cls
@@ -26,6 +26,12 @@ global virtual class MyTriggers {
     @TestVisible
     private static String triggerEventMock;
 
+    /**
+     * used to store type of current instance for the recursion control in the variable alreadyUpdatedIdsPerClass
+     * this is required due to some limitations in apex, which don't allow retrieving the type of an instance
+     */
+    private Type handlerType;
+
 	/**
      * cast records to appropriate sObjectType in implementations
      */
@@ -42,11 +48,15 @@ global virtual class MyTriggers {
     /**
      * used instead of constructor since handlers are instanciated with an empty contructor
      * @param  records Array of sObjects. for INSERT & UPDATE Trigger.new otherwise Trigger.old
+     * @param classNamespacePrefix namespace of the class that is constructed (required for per class recursion control)
+     * @param className class name of the class
      * @return         instance
      */
-    global virtual myTriggers doConstruct(sObject[] records){
+    global virtual myTriggers doConstruct(sObject[] records, Type handlerType){
 
     	this.records = records;
+        this.handlerType = handlerType;
+
         return this;
     }
 	
@@ -146,6 +156,26 @@ global virtual class MyTriggers {
         alreadyUpdatedIds.addAll(idSet);    
     }
 
+    /**
+     *Contains a map of Type.getName() and a set of already updated Ids
+     *the getRecordsNotYetProcessed() method only returns Ids where the Ids are neither included in
+     *the alreadyUpdatedIds set or in the alreadyUpdatedIdsForType.get(<<currentType>>.getName()) set
+     */
+    static Map<string, Set<Id>> alreadyUpdatedIdsForType = new Map<string, Set<Id>>(); 
+ 
+    /**
+     * add set of ids to updatedIds
+     * @param  idSet usally Trigger.newMap.keyset()
+     */
+    global void addUpdatedIdsForType(Set<Id> idSet){
+        if(!alreadyUpdatedIdsForType.containsKey(handlerType.getName()))
+        {
+            alreadyUpdatedIdsForType.put(handlerType.getName(), new Set<Id>());
+        }
+
+        alreadyUpdatedIdsForType.get(handlerType.getName()).addAll(idSet);    
+    }
+
     
     /**
      * return all updated ids
@@ -167,8 +197,18 @@ global virtual class MyTriggers {
         recordsNotYetProcessed.clear();
 
         for (sObject record : records) {
-        	if (!updatedIds.contains((Id)record.get('Id'))) {
-        		recordsNotYetProcessed.add(record);
+            Id recordId = (Id)record.get('Id');
+        	if (!updatedIds.contains(recordId)) {
+                if(alreadyUpdatedIdsForType.containsKey(handlerType.getName())){
+                    if(!alreadyUpdatedIdsForType.get(handlerType.getName()).contains(recordId)){
+                        //add if the id is neither in the updatedIds set and in the alreadyUpdatedIdsPerClass.get(classFullName) set
+                        recordsNotYetProcessed.add(record);
+                    }
+                }
+                else {
+                    //add if the id is not in the updatedIds set and no set for this class exists in the alreadyUpdatedIdsPerClass map
+                    recordsNotYetProcessed.add(record);
+                }
         	}
         }
 
@@ -580,27 +620,27 @@ global virtual class MyTriggers {
         Set<String> disabledTriggerEvents = getDisabledEvents(handlerType);
         if (isBefore) {
             if (isInsert && !disabledTriggerEvents.contains(System.TriggerOperation.BEFORE_INSERT.name())) {
-                handler.doConstruct(triggerNew).onBeforeInsert(); 
+                handler.doConstruct(triggerNew, handlerType).onBeforeInsert(); 
             }
             else if (isUpdate && !disabledTriggerEvents.contains(System.TriggerOperation.BEFORE_UPDATE.name())) {
-                 handler.doConstruct(triggerNew).onBeforeUpdate(triggerOldMap);
+                 handler.doConstruct(triggerNew, handlerType).onBeforeUpdate(triggerOldMap);
             }
             else if (isDelete && !disabledTriggerEvents.contains(System.TriggerOperation.BEFORE_DELETE.name())) {
-                 handler.doConstruct(triggerOldMap.values()).onBeforeDelete();
+                 handler.doConstruct(triggerOldMap.values(), handlerType).onBeforeDelete();
             }
         } else {
             if (isInsert && !disabledTriggerEvents.contains(System.TriggerOperation.AFTER_INSERT.name())) {
-                handler.doConstruct(triggerNew).onAfterInsert();
+                handler.doConstruct(triggerNew, handlerType).onAfterInsert();
             } 
             else if (isUpdate && !disabledTriggerEvents.contains(System.TriggerOperation.AFTER_UPDATE.name())) {
                 system.debug('On After Handler: ' + handler);
-                handler.doConstruct(triggerNew).onAfterUpdate(triggerOldMap);
+                handler.doConstruct(triggerNew, handlerType).onAfterUpdate(triggerOldMap);
             }
             else if (isDelete && !disabledTriggerEvents.contains(System.TriggerOperation.AFTER_DELETE.name())) {
-                handler.doConstruct(triggerOldMap.values()).onAfterDelete();
+                handler.doConstruct(triggerOldMap.values(), handlerType).onAfterDelete();
             }
             else if (isUndelete && !disabledTriggerEvents.contains(System.TriggerOperation.AFTER_UNDELETE.name())) {
-                handler.doConstruct(triggerNew).onAfterUndelete();
+                handler.doConstruct(triggerNew, handlerType).onAfterUndelete();
             }
         }
     }

--- a/MyTriggers/framework/classes/MyTriggers.cls
+++ b/MyTriggers/framework/classes/MyTriggers.cls
@@ -26,12 +26,6 @@ global virtual class MyTriggers {
     @TestVisible
     private static String triggerEventMock;
 
-    /**
-     * Used to store type of current instance for the recursion control in the variable alreadyUpdatedIdsPerClass
-     * this is required due to some limitations in apex, which don't allow retrieving the type of an instance
-     */
-    private Type handlerType;
-
 	/**
      * cast records to appropriate sObjectType in implementations
      */
@@ -48,14 +42,11 @@ global virtual class MyTriggers {
     /**
      * used instead of constructor since handlers are instanciated with an empty contructor
      * @param  records Array of sObjects. for INSERT & UPDATE Trigger.new otherwise Trigger.old
-     * @param handlerType Type of current instance - required for recursion control
      * @return         instance
      */
-    global virtual myTriggers doConstruct(sObject[] records, Type handlerType){
+    global virtual myTriggers doConstruct(sObject[] records){
 
     	this.records = records;
-        this.handlerType = handlerType;
-
         return this;
     }
 	
@@ -156,6 +147,17 @@ global virtual class MyTriggers {
     }
 
     /**
+     * Returns the class name of the current instance
+     * Assumption 1: class does not override the toSring() method
+     * Assumption 2: It is not required to differentiate between top level classes and subclasses 
+     * (e.g.: MyTriggersTest.AccountHandler and AccountHandler are treated as the same class)
+    */
+    @TestVisible
+    private String getClassName(){
+        return String.valueOf(this).substringBefore(':');
+    }
+
+    /**
      * Contains a map of Type.getName() and a set of already updated Ids
      * the getRecordsNotYetProcessed() method only returns Ids where the Ids are neither included in
      * the alreadyUpdatedIds set or in the alreadyUpdatedIdsForType.get(<<currentType>>.getName()) set
@@ -167,12 +169,12 @@ global virtual class MyTriggers {
      * @param  idSet usally Trigger.newMap.keyset()
      */
     global void addUpdatedIdsForType(Set<Id> idSet){
-        if(!alreadyUpdatedIdsForType.containsKey(handlerType.getName()))
+        if(!alreadyUpdatedIdsForType.containsKey(getClassName()))
         {
-            alreadyUpdatedIdsForType.put(handlerType.getName(), new Set<Id>());
+            alreadyUpdatedIdsForType.put(getClassName(), new Set<Id>());
         }
 
-        alreadyUpdatedIdsForType.get(handlerType.getName()).addAll(idSet);    
+        alreadyUpdatedIdsForType.get(getClassName()).addAll(idSet);    
     }
 
     
@@ -197,18 +199,15 @@ global virtual class MyTriggers {
 
         for (sObject record : records) {
             Id recordId = (Id)record.get('Id');
-        	if (!updatedIds.contains(recordId)) {
-                if(alreadyUpdatedIdsForType.containsKey(handlerType.getName())){
-                    if(!alreadyUpdatedIdsForType.get(handlerType.getName()).contains(recordId)){
-                        //add if the id is neither in the updatedIds set and in the alreadyUpdatedIdsPerClass.get(classFullName) set
-                        recordsNotYetProcessed.add(record);
-                    }
-                }
-                else {
-                    //add if the id is not in the updatedIds set and no set for this class exists in the alreadyUpdatedIdsPerClass map
-                    recordsNotYetProcessed.add(record);
-                }
-        	}
+            //add if the id is neither in the updatedIds set and in the alreadyUpdatedIdsPerClass.get(getClassName()) set
+            if(!updatedIds.contains(recordId) && alreadyUpdatedIdsForType.containsKey(getClassName())
+            && !alreadyUpdatedIdsForType.get(getClassName()).contains(recordId)){
+                recordsNotYetProcessed.add(record);
+            }
+            //add if the id is not in the updatedIds set and no set for this class exists in the alreadyUpdatedIdsPerClass map
+            else if(!updatedIds.contains(recordId) && !alreadyUpdatedIdsForType.containsKey(getClassName())) {
+                recordsNotYetProcessed.add(record);
+            }
         }
 
         return recordsNotYetProcessed;
@@ -619,27 +618,27 @@ global virtual class MyTriggers {
         Set<String> disabledTriggerEvents = getDisabledEvents(handlerType);
         if (isBefore) {
             if (isInsert && !disabledTriggerEvents.contains(System.TriggerOperation.BEFORE_INSERT.name())) {
-                handler.doConstruct(triggerNew, handlerType).onBeforeInsert(); 
+                handler.doConstruct(triggerNew).onBeforeInsert(); 
             }
             else if (isUpdate && !disabledTriggerEvents.contains(System.TriggerOperation.BEFORE_UPDATE.name())) {
-                 handler.doConstruct(triggerNew, handlerType).onBeforeUpdate(triggerOldMap);
+                 handler.doConstruct(triggerNew).onBeforeUpdate(triggerOldMap);
             }
             else if (isDelete && !disabledTriggerEvents.contains(System.TriggerOperation.BEFORE_DELETE.name())) {
-                 handler.doConstruct(triggerOldMap.values(), handlerType).onBeforeDelete();
+                 handler.doConstruct(triggerOldMap.values()).onBeforeDelete();
             }
         } else {
             if (isInsert && !disabledTriggerEvents.contains(System.TriggerOperation.AFTER_INSERT.name())) {
-                handler.doConstruct(triggerNew, handlerType).onAfterInsert();
+                handler.doConstruct(triggerNew).onAfterInsert();
             } 
             else if (isUpdate && !disabledTriggerEvents.contains(System.TriggerOperation.AFTER_UPDATE.name())) {
                 system.debug('On After Handler: ' + handler);
-                handler.doConstruct(triggerNew, handlerType).onAfterUpdate(triggerOldMap);
+                handler.doConstruct(triggerNew).onAfterUpdate(triggerOldMap);
             }
             else if (isDelete && !disabledTriggerEvents.contains(System.TriggerOperation.AFTER_DELETE.name())) {
-                handler.doConstruct(triggerOldMap.values(), handlerType).onAfterDelete();
+                handler.doConstruct(triggerOldMap.values()).onAfterDelete();
             }
             else if (isUndelete && !disabledTriggerEvents.contains(System.TriggerOperation.AFTER_UNDELETE.name())) {
-                handler.doConstruct(triggerNew, handlerType).onAfterUndelete();
+                handler.doConstruct(triggerNew).onAfterUndelete();
             }
         }
     }

--- a/MyTriggers/framework/classes/MyTriggers.cls
+++ b/MyTriggers/framework/classes/MyTriggers.cls
@@ -27,7 +27,7 @@ global virtual class MyTriggers {
     private static String triggerEventMock;
 
     /**
-     * used to store type of current instance for the recursion control in the variable alreadyUpdatedIdsPerClass
+     * Used to store type of current instance for the recursion control in the variable alreadyUpdatedIdsPerClass
      * this is required due to some limitations in apex, which don't allow retrieving the type of an instance
      */
     private Type handlerType;
@@ -48,8 +48,7 @@ global virtual class MyTriggers {
     /**
      * used instead of constructor since handlers are instanciated with an empty contructor
      * @param  records Array of sObjects. for INSERT & UPDATE Trigger.new otherwise Trigger.old
-     * @param classNamespacePrefix namespace of the class that is constructed (required for per class recursion control)
-     * @param className class name of the class
+     * @param handlerType Type of current instance - required for recursion control
      * @return         instance
      */
     global virtual myTriggers doConstruct(sObject[] records, Type handlerType){
@@ -157,9 +156,9 @@ global virtual class MyTriggers {
     }
 
     /**
-     *Contains a map of Type.getName() and a set of already updated Ids
-     *the getRecordsNotYetProcessed() method only returns Ids where the Ids are neither included in
-     *the alreadyUpdatedIds set or in the alreadyUpdatedIdsForType.get(<<currentType>>.getName()) set
+     * Contains a map of Type.getName() and a set of already updated Ids
+     * the getRecordsNotYetProcessed() method only returns Ids where the Ids are neither included in
+     * the alreadyUpdatedIds set or in the alreadyUpdatedIdsForType.get(<<currentType>>.getName()) set
      */
     static Map<string, Set<Id>> alreadyUpdatedIdsForType = new Map<string, Set<Id>>(); 
  

--- a/MyTriggers/framework/classes/MyTriggersTest.cls
+++ b/MyTriggers/framework/classes/MyTriggersTest.cls
@@ -172,11 +172,36 @@ private class MyTriggersTest {
 			new User(Id = null)
 		};
 
-		hndl.doConstruct(records);
+		hndl.doConstruct(records, AccountHandler.class);
 		myTriggers.addUpdatedIds(new Set<Id>{UserInfo.getUserId()});
 
 		system.assertEquals(true,myTriggers.getUpdatedIds().contains(UserInfo.getUserId()));
 		system.assertEquals(null,hndl.getNonRecursiveRecords().get(0).Id,'should not return any record which id is returned by myTriggers.getUpdatedIds()');
+
+		Test.stopTest();
+	}
+
+	// test for recusion control per class
+	private static testMethod void recursionControlPerClassTest(){
+
+		Test.startTest();
+
+		AccountHandler hndl = new AccountHandler();
+		sObject[] records = new sObject[] {
+			new User(Id = UserInfo.getUserId()),
+			new User(Id = null)
+		};
+
+		hndl.doConstruct(records, AccountHandler.class);
+		hndl.addUpdatedIdsForType(new Set<Id>{UserInfo.getUserId()});
+
+		system.assertEquals(false,myTriggers.getUpdatedIds().contains(UserInfo.getUserId()));
+		system.assertEquals(null,hndl.getNonRecursiveRecords().get(0).Id,'should not return any record which id is returned by myTriggers.getUpdatedIds()');
+
+		//a different class name must be used here!
+		AccountHandlerWithoutOverride hndl2 = new AccountHandlerWithoutOverride();
+		hndl2.doConstruct(records, AccountHandlerWithoutOverride.class);
+		system.assertEquals(UserInfo.getUserId(),hndl2.getRecordsNotYetProcessed().get(0).Id,'recursion control of hndl should not influnce recursion control of hndl2 if addUpdatedIdsForClass method is used');
 
 		Test.stopTest();
 	}

--- a/MyTriggers/framework/classes/MyTriggersTest.cls
+++ b/MyTriggers/framework/classes/MyTriggersTest.cls
@@ -172,7 +172,7 @@ private class MyTriggersTest {
 			new User(Id = null)
 		};
 
-		hndl.doConstruct(records, AccountHandler.class);
+		hndl.doConstruct(records);
 		myTriggers.addUpdatedIds(new Set<Id>{UserInfo.getUserId()});
 
 		system.assertEquals(true,myTriggers.getUpdatedIds().contains(UserInfo.getUserId()));
@@ -181,27 +181,38 @@ private class MyTriggersTest {
 		Test.stopTest();
 	}
 
+	// test if MyTriggers.getClassName() returns the class name
+	private static testMethod void getClassNameTest()
+	{
+		AccountHandler hndl = new AccountHandler();
+		String className = hndl.getClassName();
+		//getClassName doesn't yield the fully qualified class name, but only the last part if the class is a subclasses
+		//(e.g. MyTriggersTest.AccountHandler -> AccountHandler)
+		system.assertEquals(className,('.'+String.valueOf(AccountHandler.class)).substringAfterLast('.'), 'Class names don\'t match. Change in Salesforce API?');
+	}
+
 	// test for recusion control per class
-	private static testMethod void recursionControlPerClassTest(){
+	private static testMethod void recursionControlPerTypeTest(){
 
 		Test.startTest();
 
 		AccountHandler hndl = new AccountHandler();
+		User u1 = new User(Id = UserInfo.getUserId());
 		sObject[] records = new sObject[] {
-			new User(Id = UserInfo.getUserId()),
+			u1,
 			new User(Id = null)
 		};
 
-		hndl.doConstruct(records, AccountHandler.class);
-		hndl.addUpdatedIdsForType(new Set<Id>{UserInfo.getUserId()});
+		hndl.doConstruct(records);
+		hndl.addUpdatedIdsForType(new Set<Id>{u1.Id});
 
-		system.assertEquals(false,myTriggers.getUpdatedIds().contains(UserInfo.getUserId()));
-		system.assertEquals(null,hndl.getNonRecursiveRecords().get(0).Id,'should not return any record which id is returned by myTriggers.getUpdatedIds()');
+		system.assert(!myTriggers.getUpdatedIds().contains(u1.Id), 'The global (class-independent) list of updated ids should not contain the Id added with addUpdatedIdsForType(...)');
+		system.assert(!hndl.getRecordsNotYetProcessed().contains(u1),'Should not return the id added with addUpdatedIdsForType(...)');
 
 		//a different class name must be used here!
 		AccountHandlerWithoutOverride hndl2 = new AccountHandlerWithoutOverride();
-		hndl2.doConstruct(records, AccountHandlerWithoutOverride.class);
-		system.assertEquals(UserInfo.getUserId(),hndl2.getRecordsNotYetProcessed().get(0).Id,'recursion control of hndl should not influnce recursion control of hndl2 if addUpdatedIdsForClass method is used');
+		hndl2.doConstruct(records);
+		system.assert(hndl2.getRecordsNotYetProcessed().contains(u1),'Recursion control of hndl should not affect recursion control of hndl2 if addUpdatedIdsForType(...) method is used');
 
 		Test.stopTest();
 	}

--- a/README.md
+++ b/README.md
@@ -213,6 +213,9 @@ for (sObjectField field : MyTriggers.getChangedFields(fieldsToCheck,record,recor
 // add all records in the current update context
 MyTriggers.addUpdatedIds(triggerOldMap.keySet());
 
+// if the recursion control should be limited to a specific trigger handler class, use:
+this.addUpdatedIdsForType(triggerOldMap.keySet());
+
 // and use this to return only records which havent been processed before
 List<Sobject> untouchedRecords = MyTriggers.getRecordsNotYetProcessed();
 ```


### PR DESCRIPTION
I've added a recursion control per type (addUpdatedIdsForType). This allows to implement a recursion control on multiple trigger handlers of the same trigger which does not affect each other. This follows the idea that the trigger handlers are independent and don't need to know about each other.

Let me know if this works for you. It should not affect any current implementations as I didn't change the signature of any global methods. 

Also works with namespaced classes as Type.getName() returns the fully qualified name.
